### PR TITLE
fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,9 +1130,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.at": {
       "version": "4.6.0",
@@ -1155,9 +1155,9 @@
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.snakecase": {
       "version": "4.1.1",


### PR DESCRIPTION
#### Resolves 2 vulnerabilities:
|||
|------------|-------------|
| High          | Prototype Pollution                                          |
| Package       | lodash                                                       |
| Dependency of | lib-logger                                                   |
| Path          | lib-logger > winston > async > lodash                        |
| More info     | https://npmjs.com/advisories/1065                            |

|||
|------------|-------------|
| High          | Prototype Pollution                                          |
| Package       | lodash.merge                                                 |
| Dependency of | @google-cloud/pubsub                                         |
| Path          | @google-cloud/pubsub > lodash.merge                          |
| More info     | https://npmjs.com/advisories/1066                            |