### PR TITLE
Allow customized options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { PubSub } = require("@google-cloud/pubsub");
 const logger = require("lib-logger");
 
-async function subscribe(topic_name, subscription_name, subscriber) {    
+async function subscribe(topic_name, subscription_name, subscriber, options) {
   const pubsub = new PubSub();
   try {
     logger.info(`Creating subscription ${subscription_name} on topic ${topic_name}`)
@@ -15,11 +15,15 @@ async function subscribe(topic_name, subscription_name, subscriber) {
     }
   }
 
-  const subscription = pubsub.subscription(subscription_name, {
+  // Default subscriber options
+  // Documentation here https://cloud.google.com/pubsub/docs/pull#config
+  const defaultOptions = {
     flowControl: {
       maxMessages: 10,
     },
-  });
+  };
+
+  const subscription = pubsub.subscription(subscription_name, options || defaultOptions);
 
   logger.info(`Listening...`);
   subscription.on(`message`, async function processMessage(message) {


### PR DESCRIPTION
With this change, whoever using the library can pass their own subscriber options.
For example we can pass some of the following options
```
const subscriberOptions = {
  ackDeadline: 10,
  batching: {
    // https://googleapis.github.io/gax-nodejs/CallSettings.html}
    callOptions: {...},
    maxMessages: 3000,
    maxMilliseconds: 100
  },
  flowControl: {
    allowExcessMessages: true,
    maxBytes: os.freemem() * 0.2,
    maxExtension: Infinity,
    maxMessages: 100
  },
  streamingOptions: {
    highWaterMark: 0,
    maxStreams: 5,
    timeout: 300000
  }
};
subscribe(topic, subscription, onMessage, subscriberOptions)
```
If subscriberOptions is not provided, we will use default options. If subscriberOptions is `{}` or `[]` or `""` or `null` or `undefined`, or anything that the Pubsub API can't understand, it will use default options.

Documentation is here: https://cloud.google.com/pubsub/docs/pull
Related comments on pubsub subscriber options here: https://github.com/googleapis/nodejs-pubsub/issues/696
